### PR TITLE
Use context to manage ffmpeg subprocesses

### DIFF
--- a/pkg/audio/interfaces.go
+++ b/pkg/audio/interfaces.go
@@ -1,6 +1,7 @@
 package audio
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -24,11 +25,11 @@ type AudioPipeline interface {
 
 // StreamProcessor handles the FFmpeg process and audio stream generation
 type StreamProcessor interface {
-	StartStream(url string) (io.ReadCloser, error)
+	StartStream(ctx context.Context, url string) (io.ReadCloser, error)
 	Stop() error
 	IsRunning() bool
 	IsProcessAlive() bool
-	Restart(url string) error
+	Restart(ctx context.Context, url string) error
 	WaitForExit(timeout time.Duration) error
 	GetProcessInfo() map[string]interface{}
 

--- a/pkg/audio/pipeline.go
+++ b/pkg/audio/pipeline.go
@@ -385,7 +385,7 @@ func (c *AudioPipelineController) executePlayback(url string, voiceConn *discord
 
 	// Step 3: Start the stream processor
 	c.logger.Debug("Starting stream processor", contextFields)
-	stream, err := c.streamProcessor.StartStream(url)
+	stream, err := c.streamProcessor.StartStream(c.ctx, url)
 	if err != nil {
 		c.logger.Error("Stream processor start failed", err, contextFields)
 		return c.handlePlaybackError(err, "stream_start")

--- a/test/audio/ffmpeg_streaming_test.go
+++ b/test/audio/ffmpeg_streaming_test.go
@@ -1,6 +1,7 @@
 package audio
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestFFmpegRetryLogic(t *testing.T) {
 	// Test with invalid URL to trigger retry logic
 	invalidURL := "https://invalid-url-that-should-fail.com/test"
 
-	_, err := processor.StartStream(invalidURL)
+	_, err := processor.StartStream(context.Background(), invalidURL)
 
 	// We expect an error for invalid URL, but let's be more flexible about what error we get
 	// The important thing is that the retry logic is implemented

--- a/test/audio/integration_test.go
+++ b/test/audio/integration_test.go
@@ -147,7 +147,7 @@ func TestYtDlpPipingWithRealURL(t *testing.T) {
 
 	go func() {
 		var err error
-		reader, err = processor.StartStream(testURL)
+		reader, err = processor.StartStream(ctx, testURL)
 		done <- err
 	}()
 
@@ -409,7 +409,7 @@ func TestManualYouTubeURLs(t *testing.T) {
 
 			go func() {
 				var err error
-				reader, err = processor.StartStream(testCase.url)
+				reader, err = processor.StartStream(ctx, testCase.url)
 				done <- err
 			}()
 
@@ -519,7 +519,7 @@ func TestStreamingPipelineRobustness(t *testing.T) {
 	t.Run("invalid_url", func(t *testing.T) {
 		invalidURL := "https://invalid-url-that-does-not-exist.com/test"
 
-		_, err := processor.StartStream(invalidURL)
+		_, err := processor.StartStream(context.Background(), invalidURL)
 		if err == nil {
 			t.Error("Expected error for invalid URL")
 		} else {
@@ -539,7 +539,7 @@ func TestStreamingPipelineRobustness(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			t.Logf("Cycle %d: Starting stream", i+1)
 
-			reader, err := processor.StartStream(testURL)
+			reader, err := processor.StartStream(context.Background(), testURL)
 			if err != nil {
 				t.Logf("Cycle %d failed to start: %v", i+1, err)
 				continue
@@ -575,7 +575,7 @@ func TestStreamingPipelineRobustness(t *testing.T) {
 		}
 
 		testURL := "https://www.youtube.com/watch?v=jNQXAC9IVRw"
-		reader, err := processor.StartStream(testURL)
+		reader, err := processor.StartStream(context.Background(), testURL)
 		if err != nil {
 			t.Logf("Failed to start for process info test: %v", err)
 			return


### PR DESCRIPTION
## Summary
- Switch FFmpeg stream processor to `exec.CommandContext` and derive subprocess contexts from the pipeline controller
- Drop manual process termination logic in favor of context cancellation
- Pass pipeline context through the controller to ensure cleanup on shutdown

## Testing
- `go test ./...` *(fails: yt-dlp not found, ffmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ae813f883258e6223759b54da32