### PR TITLE
feat: add exponential backoff with jitter

### DIFF
--- a/pkg/audio/ffmpeg.go
+++ b/pkg/audio/ffmpeg.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"os/exec"
 	"strings"
 	"sync"
@@ -104,6 +105,12 @@ func (fp *FFmpegProcessor) startStreamWithRetry(url string, urlLogger AudioLogge
 		contextFields["max_attempts"] = fp.maxRetries + 1
 
 		if attempt > 0 {
+			baseDelay := time.Second
+			expDelay := baseDelay * time.Duration(1<<attempt)
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			jitter := time.Duration(r.Int63n(int64(baseDelay)))
+			delay := expDelay + jitter
+			contextFields["backoff_delay"] = delay.String()
 			urlLogger.Info("Retrying stream start", contextFields)
 
 			// Check if failure might be due to URL expiry and try refresh (Requirement 8.2, 6.1)
@@ -122,8 +129,6 @@ func (fp *FFmpegProcessor) startStreamWithRetry(url string, urlLogger AudioLogge
 				}
 			}
 
-			// Simple delay between retries: 2s, 5s, 10s (Requirement 6.1)
-			delay := time.Duration(2+attempt*3) * time.Second
 			time.Sleep(delay)
 		} else {
 			urlLogger.Info("Starting streaming pipeline", contextFields)


### PR DESCRIPTION
## Summary
- use exponential backoff with jitter when retrying stream start
- log calculated backoff delay

## Testing
- `go test ./...` *(fails: yt-dlp and ffmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac97ac28488325be0d65676c997af1